### PR TITLE
Boosted and LP BIFI tracking

### DIFF
--- a/abis/LP.json
+++ b/abis/LP.json
@@ -1,0 +1,34 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -1,0 +1,557 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_token",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_strategy",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "_name",
+                "type": "string"
+            },
+            {
+                "internalType": "string",
+                "name": "_symbol",
+                "type": "string"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_approvalDelay",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "NewStratCandidate",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "UpgradeStrat",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "approvalDelay",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "available",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "balance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "subtractedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "depositAll",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "earn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getPricePerFullShare",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_token",
+                "type": "address"
+            }
+        ],
+        "name": "inCaseTokensGetStuck",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "addedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_implementation",
+                "type": "address"
+            }
+        ],
+        "name": "proposeStrat",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "stratCandidate",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "proposedTime",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "strategy",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "token",
+        "outputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "upgradeStrat",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_shares",
+                "type": "uint256"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "withdrawAll",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "gpl-3.0",
   "private": true,
   "dependencies": {
+    "axios": "^0.21.1",
     "ethers": "^5.3.0",
     "loglevel": "^1.7.1"
   },

--- a/src/abis.js
+++ b/src/abis.js
@@ -3,6 +3,8 @@ abis.bifi = require('../abis/Bifi.json');
 abis.maxi = require('../abis/Maxi.json');
 abis.rewards = require('../abis/Rewards.json');
 abis.multicall = require('../abis/Multicall.json');
+abis.vault = require('../abis/Vault.json');
+abis.lps = require('../abis/LP.json');
 
 module.exports = {
   abis,

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -3,7 +3,7 @@ const { getProvider, sleep } = require('./utils');
 const { chains } = require('./chains');
 const { abis } = require ('./abis');
 const { log } = require('./log');
-const axios = require('axios');
+const { getMooBifiBoostAddresses } = require('./stakes');
 
 async function analyze (hodlers) {
   log.info(`analyzing hodlers: ${hodlers.length}`);
@@ -34,26 +34,6 @@ async function analyze (hodlers) {
   return balances;
 }
 
-async function getMooBifiBoostAddresses(chain) {
-  let resp = await axios.get(chain.stakes);
-  let stakesString = resp.data;
-
-  //Retrieve only necessary array;
-  let index = stakesString.indexOf('[');
-  stakesString = stakesString.slice(index);
-  stakesString = stakesString.replace(';', '');
-  stakesString = stakesString.replace(/,*;*\s*\n*$/, "");
-
-  const govPoolABI = ''; //required to perform eval since json has object as value
-  let stakes = eval('(' + stakesString + ')');
-
-  let bifiBoostAddresses = stakes
-    .filter(stake => stake.tokenAddress.toLocaleLowerCase() === chain.maxi.toLocaleLowerCase())
-    .map(mooBoost => mooBoost.earnContractAddress);
-
-  return bifiBoostAddresses;
-}
-
 async function analyzeChain (id, hodlers) {
   log.info(`analyzing chain: ${id}`);
   const chain = chains[id];
@@ -62,7 +42,7 @@ async function analyzeChain (id, hodlers) {
   let provider = getProvider(chain.rpc);
   const multicall = new Contract(chain.multicall.address, abis.multicall, provider);
   const batch_size = chain.multicall.batch;
-  const boosts = await getMooBifiBoostAddresses(chain);  
+  const boosts = await getMooBifiBoostAddresses(chain);
   const targets = [chain.bifi, chain.rewards, chain.maxi, ...boosts];
 
   let maxi_pps = 1;

--- a/src/chains.js
+++ b/src/chains.js
@@ -62,12 +62,11 @@ const chains = {
       batch: 500
     },
     rpc: [
+      'https://polygon-rpc.com',
       'https://rpc-mainnet.matic.network',
       'https://rpc-mainnet.maticvigil.com',
       'https://rpc-mainnet.matic.quiknode.pro',
       'https://matic-mainnet.chainstacklabs.com',
-      'https://matic-mainnet-full-rpc.bwarelabs.com',
-      'https://matic-mainnet-archive-rpc.bwarelabs.com'
     ],
     query: {
       limit: 1000,

--- a/src/chains.js
+++ b/src/chains.js
@@ -65,11 +65,11 @@ const chains = {
       batch: 350
     },
     rpc: [
-      'https://polygon-rpc.com'
-      // 'https://rpc-mainnet.matic.network',
-      // 'https://rpc-mainnet.maticvigil.com',
-      // 'https://rpc-mainnet.matic.quiknode.pro',
-      // 'https://matic-mainnet.chainstacklabs.com',
+      'https://polygon-rpc.com',
+      'https://rpc-mainnet.matic.network',
+      'https://rpc-mainnet.maticvigil.com',
+      'https://rpc-mainnet.matic.quiknode.pro',
+      'https://matic-mainnet.chainstacklabs.com',
     ],
     query: {
       limit: 1000,

--- a/src/chains.js
+++ b/src/chains.js
@@ -8,7 +8,7 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/bsc_pools.js',
     multicall: {
       address: '0x8B326CA2A9c15b1730dBF21d396eB3a282EAC04B',
-      batch: 250
+      batch: 350
     },
     rpc: [
       'https://bsc-dataseed.binance.org/',
@@ -42,7 +42,7 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/heco_pools.js',
     multicall: {
       address: '0x92BC92304Fe5f85D6451e890EBd46606Eaf354eb',
-      batch: 500
+      batch: 350
     },
     rpc: ['https://http-mainnet.hecochain.com'],
     query: {
@@ -62,14 +62,14 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/polygon_pools.js',
     multicall: {
       address: '0x9FE5D998c39B5B6d6Fc4a5ad1E54Af40974C0F02',
-      batch: 500
+      batch: 350
     },
     rpc: [
-      'https://polygon-rpc.com',
-      'https://rpc-mainnet.matic.network',
-      'https://rpc-mainnet.maticvigil.com',
-      'https://rpc-mainnet.matic.quiknode.pro',
-      'https://matic-mainnet.chainstacklabs.com',
+      'https://polygon-rpc.com'
+      // 'https://rpc-mainnet.matic.network',
+      // 'https://rpc-mainnet.maticvigil.com',
+      // 'https://rpc-mainnet.matic.quiknode.pro',
+      // 'https://matic-mainnet.chainstacklabs.com',
     ],
     query: {
       limit: 1000,
@@ -88,7 +88,7 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/fantom_pools.js',
     multicall: {
       address: '0x81eA78BddEfFe1e1A150A3cac2272D6d9511d26e',
-      batch: 500
+      batch: 350
     },
     rpc: [
       'https://rpc.ftm.tools',
@@ -111,7 +111,7 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/avalanche_pools.js',
     multicall: {
       address: '0x744eC1752Ab3b18AE786A051197a55112069BdDE',
-      batch: 500
+      batch: 350
     },
     rpc: ['https://api.avax.network/ext/bc/C/rpc'],
     query: {

--- a/src/chains.js
+++ b/src/chains.js
@@ -99,7 +99,7 @@ const chains = {
     id: 43114,
     bifi: '0xd6070ae98b8069de6b494332d1a1a81b6179d960',
     rewards: '0x86d38c6b6313c5A3021D68D1F57CF5e69197592A',
-    maxi: '0x0000000000000000000000000000000000000000',
+    maxi: '0xCeefB07Ad37ff165A0b03DC7C808fD2E2fC77683',
     multicall: {
       address: '0x744eC1752Ab3b18AE786A051197a55112069BdDE',
       batch: 500

--- a/src/chains.js
+++ b/src/chains.js
@@ -4,6 +4,7 @@ const chains = {
     bifi: '0xca3f508b8e4dd382ee878a314789373d80a5190a',
     rewards: '0x453D4Ba9a2D594314DF88564248497F7D74d6b2C',
     maxi: '0xf7069e41C57EcC5F122093811d8c75bdB5f7c14e',
+    stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/bsc_stake.js',
     multicall: {
       address: '0x8B326CA2A9c15b1730dBF21d396eB3a282EAC04B',
       batch: 500
@@ -36,6 +37,7 @@ const chains = {
     bifi: '0x765277eebeca2e31912c9946eae1021199b39c61',
     rewards: '0x5f7347fedfD0b374e8CE8ed19Fc839F59FB59a3B',
     maxi: '0x688724Fb44cD7eabF209Ca2B225880033e9563d2',
+    stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/heco_stake.js',
     multicall: {
       address: '0x92BC92304Fe5f85D6451e890EBd46606Eaf354eb',
       batch: 500
@@ -54,6 +56,7 @@ const chains = {
     bifi: '0xfbdd194376de19a88118e84e279b977f165d01b8',
     rewards: '0xDeB0a777ba6f59C78c654B8c92F80238c8002DD2',
     maxi: '0xfEcf784F48125ccb7d8855cdda7C5ED6b5024Cb3',
+    stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/polygon_stake.js',
     multicall: {
       address: '0x9FE5D998c39B5B6d6Fc4a5ad1E54Af40974C0F02',
       batch: 500
@@ -79,6 +82,7 @@ const chains = {
     bifi: '0xd6070ae98b8069de6b494332d1a1a81b6179d960',
     rewards: '0x7fB900C14c9889A559C777D016a885995cE759Ee',
     maxi: '0xbF07093ccd6adFC3dEB259C557b61E94c1F66945',
+    stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/fantom_stake.js',
     multicall: {
       address: '0x81eA78BddEfFe1e1A150A3cac2272D6d9511d26e',
       batch: 500
@@ -100,6 +104,7 @@ const chains = {
     bifi: '0xd6070ae98b8069de6b494332d1a1a81b6179d960',
     rewards: '0x86d38c6b6313c5A3021D68D1F57CF5e69197592A',
     maxi: '0xCeefB07Ad37ff165A0b03DC7C808fD2E2fC77683',
+    stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/avalanche_stake.js',
     multicall: {
       address: '0x744eC1752Ab3b18AE786A051197a55112069BdDE',
       batch: 500

--- a/src/chains.js
+++ b/src/chains.js
@@ -8,7 +8,7 @@ const chains = {
     vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/bsc_pools.js',
     multicall: {
       address: '0x8B326CA2A9c15b1730dBF21d396eB3a282EAC04B',
-      batch: 500
+      batch: 250
     },
     rpc: [
       'https://bsc-dataseed.binance.org/',
@@ -95,7 +95,7 @@ const chains = {
       'https://rpcapi.fantom.network'
     ],
     query: {
-      limit: 1000,
+      limit: 5000,
       interval: 100,
       sleep: 10000,
       start: 6903757,

--- a/src/chains.js
+++ b/src/chains.js
@@ -5,6 +5,7 @@ const chains = {
     rewards: '0x453D4Ba9a2D594314DF88564248497F7D74d6b2C',
     maxi: '0xf7069e41C57EcC5F122093811d8c75bdB5f7c14e',
     stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/bsc_stake.js',
+    vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/bsc_pools.js',
     multicall: {
       address: '0x8B326CA2A9c15b1730dBF21d396eB3a282EAC04B',
       batch: 500
@@ -38,6 +39,7 @@ const chains = {
     rewards: '0x5f7347fedfD0b374e8CE8ed19Fc839F59FB59a3B',
     maxi: '0x688724Fb44cD7eabF209Ca2B225880033e9563d2',
     stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/heco_stake.js',
+    vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/heco_pools.js',
     multicall: {
       address: '0x92BC92304Fe5f85D6451e890EBd46606Eaf354eb',
       batch: 500
@@ -57,6 +59,7 @@ const chains = {
     rewards: '0xDeB0a777ba6f59C78c654B8c92F80238c8002DD2',
     maxi: '0xfEcf784F48125ccb7d8855cdda7C5ED6b5024Cb3',
     stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/polygon_stake.js',
+    vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/polygon_pools.js',
     multicall: {
       address: '0x9FE5D998c39B5B6d6Fc4a5ad1E54Af40974C0F02',
       batch: 500
@@ -82,6 +85,7 @@ const chains = {
     rewards: '0x7fB900C14c9889A559C777D016a885995cE759Ee',
     maxi: '0xbF07093ccd6adFC3dEB259C557b61E94c1F66945',
     stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/fantom_stake.js',
+    vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/fantom_pools.js',
     multicall: {
       address: '0x81eA78BddEfFe1e1A150A3cac2272D6d9511d26e',
       batch: 500
@@ -104,6 +108,7 @@ const chains = {
     rewards: '0x86d38c6b6313c5A3021D68D1F57CF5e69197592A',
     maxi: '0xCeefB07Ad37ff165A0b03DC7C808fD2E2fC77683',
     stakes: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/avalanche_stake.js',
+    vaults: 'https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/avalanche_pools.js',
     multicall: {
       address: '0x744eC1752Ab3b18AE786A051197a55112069BdDE',
       batch: 500

--- a/src/stakes.js
+++ b/src/stakes.js
@@ -1,30 +1,37 @@
 const axios = require('axios');
+const {log} = require('./log');
+const { getProvider, sleep } = require('./utils');
+const { Contract } = require('ethers');
+const { abis } = require ('./abis');
+
 
 const getMooBifiBoostAddresses = async (chain) => {
     let resp = await axios.get(chain.stakes);
     
-    let boostArray = parseBoostAddresses(resp.data)
+    let boosts = parseFileArray(resp.data)
     
     //keep boosts that take moobifi as input
-    return boostArray
+    return boosts
         .filter(boost => boost.tokenAddress.toLocaleLowerCase() === chain.maxi.toLocaleLowerCase())
         .map(boost => boost.earnContractAddress);
 }
 
-const parseBoostAddresses = (boostFileString) => {
+const parseFileArray = (boostFileString) => {
     let index = boostFileString.indexOf('[');
+
     let boosts = boostFileString.slice(index);
     boosts = boosts.replace(';','');
     boosts = boosts.replace(/,*;*\s*\n*$/, "");
-    
-    const govPoolABI= ''; //required to perform eval since json has object inside key inside
+
+    const govPoolABI= '';
+    const moonpot= ''; //required to perform eval since json has object key
     
     let boostArray = [];
 
     try {
         boostArray = eval('(' + boosts + ')');
     } catch (err) {
-
+        console.log(boostFileString)
         log.debug('Failed to parse boost file string');
         log.error(err);
         boostArray = [];
@@ -33,6 +40,89 @@ const parseBoostAddresses = (boostFileString) => {
     return boostArray;
 }
 
+const getLpBifiData = async (chain) => {
+    let resp = await axios.get(chain.vaults);
+
+    let vaults = parseFileArray(resp.data);
+    
+    //Will fetch all relevant data to find bifi balance with user's moobifi balance later
+    let completeVaults = vaults
+        .filter(vault =>  vault.assets.includes('BIFI') && !vault.id.includes('bifi-maxi'))
+        .map(vault => {
+            return {
+                id: vault.id,
+                address: vault.earnContractAddress,
+                lpToken: {
+                    address:  vault.tokenAddress,
+                    decimals: vault.tokenDecimals
+                } 
+            };
+        }).map(vault => {
+            return getVaultData(vault, chain);
+        })
+        
+    return await Promise.all(completeVaults);
+}
+
+
+/*
+    Gets all the relevant information to find out how much BIFI is staked per mooLPtoken
+    User balance is fetched later and multiplied times bifiRatio * ppfs to get it's bifi balance
+*/
+const getVaultData = async (vault, chain) => {
+    let retries = 5;
+
+    let provider = getProvider(chain.rpc)
+    while (retries > 0) {
+
+        try {
+            const beefyContract = new Contract(chain.bifi, abis.bifi, provider);
+            const lpContract = new Contract(vault.lpToken.address, abis.lps, provider);
+            const vaultContract = new Contract(vault.address, abis.vault, provider);
+
+
+            let promises = [
+                beefyContract.balanceOf(vault.lpToken.address), //BIFI in LP
+                lpContract.totalSupply(), //LP totalSupply
+                vaultContract.getPricePerFullShare(), //mooToken ppfs
+                vaultContract.decimals() //mooToken decimals
+            ];
+
+            let [bifiLPBalance, lpTotalSupply, ppfs, decimals] = await Promise.all(promises);
+            const bifiRatio = (bifiLPBalance/1e18)/lpTotalSupply;
+            ppfs = ppfs / (10**decimals);
+
+            return {
+                id: vault.id,
+                address: vault.address,
+                bifiRatio,
+                ppfs
+            };
+
+        } catch (err) {
+            await sleep(2500);
+            provider = getProvider(chain.rpc);
+            log.error('retrying vault calls ' + chain.id);
+            console.log(err.message)
+        }
+        retries--;
+    }
+
+    //On continuos retries, default to 0 value for balance
+    return {
+        id: vault.id,
+        address: vault.address,
+        bifiRatio: 0,
+        ppfs: 1
+    }
+
+}
+
+
+
+
+
 module.exports = {
-    getMooBifiBoostAddresses
+    getMooBifiBoostAddresses,
+    getLpBifiData
 }

--- a/src/stakes.js
+++ b/src/stakes.js
@@ -103,7 +103,7 @@ const getVaultData = async (vault, chain) => {
             await sleep(2500);
             provider = getProvider(chain.rpc);
             log.error('retrying vault calls ' + chain.id);
-            debug.error(err.message)
+            log.error(err.message)
         }
         retries--;
     }

--- a/src/stakes.js
+++ b/src/stakes.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+
+const getMooBifiBoostAddresses = async (chain) => {
+    let resp = await axios.get(chain.stakes);
+    
+    let boostArray = parseBoostAddresses(resp.data)
+    
+    //keep boosts that take moobifi as input
+    return boostArray
+        .filter(boost => boost.tokenAddress.toLocaleLowerCase() === chain.maxi.toLocaleLowerCase())
+        .map(boost => boost.earnContractAddress);
+}
+
+const parseBoostAddresses = (boostFileString) => {
+    let index = boostFileString.indexOf('[');
+    let boosts = boostFileString.slice(index);
+    boosts = boosts.replace(';','');
+    boosts = boosts.replace(/,*;*\s*\n*$/, "");
+    
+    const govPoolABI= ''; //required to perform eval since json has object inside key inside
+    
+    let boostArray = [];
+
+    try {
+        boostArray = eval('(' + boosts + ')');
+    } catch (err) {
+
+        log.debug('Failed to parse boost file string');
+        log.error(err);
+        boostArray = [];
+    }
+
+    return boostArray;
+}
+
+module.exports = {
+    getMooBifiBoostAddresses
+}

--- a/src/stakes.js
+++ b/src/stakes.js
@@ -3,6 +3,7 @@ const {log} = require('./log');
 const { getProvider, sleep } = require('./utils');
 const { Contract } = require('ethers');
 const { abis } = require ('./abis');
+const { debug } = require('loglevel');
 
 
 const getMooBifiBoostAddresses = async (chain) => {
@@ -31,7 +32,6 @@ const parseFileArray = (boostFileString) => {
     try {
         boostArray = eval('(' + boosts + ')');
     } catch (err) {
-        console.log(boostFileString)
         log.debug('Failed to parse boost file string');
         log.error(err);
         boostArray = [];
@@ -103,7 +103,7 @@ const getVaultData = async (vault, chain) => {
             await sleep(2500);
             provider = getProvider(chain.rpc);
             log.error('retrying vault calls ' + chain.id);
-            console.log(err.message)
+            debug.error(err.message)
         }
         retries--;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,6 +346,13 @@ aes-js@3.0.0:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
@@ -409,6 +416,11 @@ ethers@^5.3.0:
     "@ethersproject/wallet" "5.3.0"
     "@ethersproject/web" "5.3.0"
     "@ethersproject/wordlists" "5.3.0"
+
+follow-redirects@^1.10.0:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.2.tgz#cecb825047c00f5e66b142f90fed4f515dec789b"
+  integrity sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==
 
 hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"


### PR DESCRIPTION
This PR works on the ability to track boosted BIFI maxi and BIFI deposited in LPs inside the beefy platform.

- Added url directions to get vaults/boosts from beefy-app
- cut down multi call batch sizes to prevent consistent rpc errors.
- removed underperforming polygon rpcs and added polygon aggregator rpc

Once the holder set is built and prior to the analyze phase:
Boosts
- Boost vaults will be retrieved and filtered to only contain those with mooBifi as input.
- They are then added to the target address list and added up as a separate boost field in the user's balance.

LPs
- LP vaults are also retrieved, parsed and filtered.
- The bifiAmount per LP token is found and cached so that only the user's mooLPToken balance is needed to complete how much BIFI they own.
- The LP addresses are added as target addresses as well and aggregated onto the lips field in the user's balance