### PR TITLE
Blacklisting and address exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # beefy-snap
 Multichain snapshot algorithm
+
+Adding a new chain:
+- The Multicall.sol contract should be deployed and verified on the given chain.
+- Chain data should be added to chains.js following the template:
+{
+    id: 250, //chain id
+    bifi: "0xd6070ae98b8069de6b494332d1a1a81b6179d960", // BIFI token address on that chain
+    rewards: "0x7fB900C14c9889A559C777D016a885995cE759Ee", // BIFI Rewards pool address on that chain
+    maxi: "0xbF07093ccd6adFC3dEB259C557b61E94c1F66945", // BIFI Maxi address on that chain
+    stakes:
+      "https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/stake/fantom_stake.js", //address from where to fetch chain boosts
+    vaults:
+      "https://raw.githubusercontent.com/beefyfinance/beefy-app/prod/src/features/configure/vault/fantom_pools.js", //address from where to fetch chain vaults
+    multicall: {
+      address: "0x81eA78BddEfFe1e1A150A3cac2272D6d9511d26e", // Address for the deployed contract on previous step
+      batch: 250, //fixed at 250
+    },
+    rpc: ["https://rpc.ftm.tools", "https://rpcapi.fantom.network"], // List of reliable RPC addresses
+    query: {
+      limit: 1000, // Log query search limit compatible with the used RPCs
+      interval: 100, // fixed at 100
+      sleep: 1500, // fixed at 1500
+      start: 6903757, // Block at which the BIFI token contract was deployed on that chain
+    },
+}
+- Ideally, the query limit should be optimized for the used RPCs. The higher the better but not all RPCs support high limits (current usage ranges from 1000 to 5000)
+
+Blacklisting an address:
+- Add an entrance to blacklist.js following:
+    "address-name": "0xe1A5B6493054D36DDaC337c2B2f407423Bf08a9F",

--- a/src/blacklist.js
+++ b/src/blacklist.js
@@ -1,0 +1,17 @@
+const blacklist = {
+  "bsc-anyswap-cronos": "0x1ab7de6ac4ef91ea4f10fabe444b9a2e727ec89b",
+  "bsc-anyswap-avalanche": "0xb1cb88b1a1992deb4189ea4f566b594c13392ada",
+  "bsc-anyswap-polygon": "0x171a9377c5013bb06bca8cfe22b9c007f2c319f1",
+  "bsc-anyswap-moonriver": "0xd6faf697504075a358524996b132b532cc5d0f14",
+  "bsc-anyswap-arbitrum": "0xad1a0d92db9157ac9ef7ee74be38940f60bcafa9",
+  "bsc-anyswap-celo": "0x6b09d3ffdb93549f03936e7eda9d4190261140f7",
+  "bsc-anyswap-harmony": "0x5b531c46db853fd0fda4736ac013d7a25e8b1083",
+  "bsc-anyswap-heco": "0xe09c98f97dafb1f954cea0ce550383e2bd0c8829",
+  "bsc-anyswap-fantom": "0x4b3b4120d4d7975455d8c2894228789c91a247f8",
+  "bsc-anyswap-polygon-2": "0xcf9f53e2222f46024b7c632689804c024c13d03c",
+  "bsc-anyswap-fantom-2": "0xe1A5B6493054D36DDaC337c2B2f407423Bf08a9F",
+};
+
+module.exports = {
+  blacklist,
+};

--- a/src/exclude.js
+++ b/src/exclude.js
@@ -5,6 +5,7 @@ const { getLpBifiData, getMooBifiBoostAddresses, getLpBifiBoostedData, getStrate
 
 var excludedAddresses = new Set();
 
+//Load all excluded lists
 const loadExcludedAddresses = async () => {
 
     Object.values(blacklist).forEach(address => {
@@ -12,17 +13,22 @@ const loadExcludedAddresses = async () => {
     });
 
     for (const chain of Object.values(chains)) {
-        excludedAddresses.add(chain.bifi.toLocaleLowerCase());
         excludedAddresses.add(chain.maxi.toLocaleLowerCase());
         excludedAddresses.add(chain.rewards.toLocaleLowerCase());
 
+        //Add Vault addresses
         let lps = await getLpBifiData(chain);
         lps.forEach(lp => excludedAddresses.add(lp.address.toLocaleLowerCase()));
+
+        //Add mooBifi boost addresses
         let boosts = await getMooBifiBoostAddresses(chain);
         boosts.forEach(boost => excludedAddresses.add(boost.toLocaleLowerCase()));
+
+        //Add BIFI vault boost addresses
         let lpBoosts = await getLpBifiBoostedData(chain);
         lpBoosts.forEach(lpBoost => excludedAddresses.add(lpBoost.address.toLocaleLowerCase()));
 
+        //Add strategy addresses fir BIFI vaults + Maxi
         const vaultAddresses = lps.map(lp => lp.address);
         let strategies = await getStrategyAddressForVaults([...vaultAddresses, chain.maxi], chain);
         strategies.forEach(strat => excludedAddresses.add(strat.toLocaleLowerCase()));

--- a/src/exclude.js
+++ b/src/exclude.js
@@ -1,0 +1,40 @@
+const { blacklist } = require("./blacklist");
+const { chains } = require("./chains");
+const { getLpBifiData, getMooBifiBoostAddresses, getLpBifiBoostedData, getStrategyAddressForVaults } = require("./stakes");
+
+
+var excludedAddresses = new Set();
+
+const loadExcludedAddresses = async () => {
+
+    Object.values(blacklist).forEach(address => {
+        excludedAddresses.add(address.toLocaleLowerCase());
+    });
+
+    for (const chain of Object.values(chains)) {
+        excludedAddresses.add(chain.bifi.toLocaleLowerCase());
+        excludedAddresses.add(chain.maxi.toLocaleLowerCase());
+        excludedAddresses.add(chain.rewards.toLocaleLowerCase());
+
+        let lps = await getLpBifiData(chain);
+        lps.forEach(lp => excludedAddresses.add(lp.address.toLocaleLowerCase()));
+        let boosts = await getMooBifiBoostAddresses(chain);
+        boosts.forEach(boost => excludedAddresses.add(boost.toLocaleLowerCase()));
+        let lpBoosts = await getLpBifiBoostedData(chain);
+        lpBoosts.forEach(lpBoost => excludedAddresses.add(lpBoost.address.toLocaleLowerCase()));
+
+        const vaultAddresses = lps.map(lp => lp.address);
+        let strategies = await getStrategyAddressForVaults([...vaultAddresses, chain.maxi], chain);
+        strategies.forEach(strat => excludedAddresses.add(strat.toLocaleLowerCase()));
+    }
+
+}
+
+const isAddressExcluded = (address) => {
+    return excludedAddresses.has(address.toLocaleLowerCase());
+}
+
+module.exports = {
+    loadExcludedAddresses,
+    isAddressExcluded
+}

--- a/src/snap.js
+++ b/src/snap.js
@@ -41,8 +41,6 @@ async function main () {
     let metadata = { hodlers: 0 };
     let hodlers = [];
 
-    loadExcludedAddresses();
-  
     if (existsSync(META_FILE)) {
       log.debug('metadata found');
 


### PR DESCRIPTION
Add functionality to exclude unwanted addresses from the final snapshot balance. This prevents double counting BIFI + giving voting power to addresses that shouldn't have it.

- Blacklisting: reads addresses from blacklist.js and excludes them from final snapshot

- Exclude Beefy addresses: BIFI Maxi, BIFI Rewards, BIFI vault and BIFI vault strat addresses from Beefy are automatically loaded and added to the exclusion list to prevent double counting. No need to manually add new vaults/pools for them to be excluded.

resolves beefyfinance/beefy-snap#1